### PR TITLE
chore: add portuguese

### DIFF
--- a/lang/pt.js
+++ b/lang/pt.js
@@ -1,0 +1,9 @@
+export default defineI18nLocale(async () => {
+  const { data } = await useGraphqlQuery(`
+  query {
+      translation(locale: pt) {
+          translations
+      }
+  }`)
+  return data.value.translation.translations
+})


### PR DESCRIPTION
@therealJonSnow. I am unaware on how the i18n works.

- DatoCMS already supports Portuguese using `pt`
- The deployments in Netifly already have the proper envinoment value to `pt`

Do we need to change something else in the code?

Thanks 

---

PS: [Sticker](https://github.com/cryptocity-network/cryptocity/blob/main/components/block/MapBusiness.vue#L158) might need translations. Currently we are missing: `pt`, `et` and `sl`.
